### PR TITLE
Suppresses `All available stacks` message in `clist` command if there is none

### DIFF
--- a/dockerbuild/python/commands/compose.py
+++ b/dockerbuild/python/commands/compose.py
@@ -72,15 +72,18 @@ def clist_stack():
     Prints all available stacks with running/all containers count.
     :return: None
     """
-    print("\nAll available stacks (running containers/all containers):")
-    for stack_stat in get_stack_containers_list().items():
-        stack_container: StackContainer
+    stack_containers_list = get_stack_containers_list().items()
 
-        running_containers_count = sum(1 for stack_container in stack_stat[1] if stack_container.running)
-        all_containers_count = len(stack_stat[1])
-        stack_name = stack_stat[0]
+    if len(stack_containers_list) > 0:
+        print("\nAll available stacks (running containers/all containers):")
+        for stack_stat in stack_containers_list:
+            stack_container: StackContainer
 
-        print("\n  - %s: %d/%d" % (stack_name, running_containers_count, all_containers_count))
+            running_containers_count = sum(1 for stack_container in stack_stat[1] if stack_container.running)
+            all_containers_count = len(stack_stat[1])
+            stack_name = stack_stat[0]
+
+            print("\n  - %s: %d/%d" % (stack_name, running_containers_count, all_containers_count))
 
 
 def logs(args):

--- a/dockerbuild/python/tools/docker_compose_tools.py
+++ b/dockerbuild/python/tools/docker_compose_tools.py
@@ -1,8 +1,8 @@
 from docker.models.containers import Container
 
-from tools.docker_common_tools import get_docker, compose_project_label, container_label_key, compose_project_dir_label, \
-    stack_namespace_label
-from tools.docker_container_tools import is_container_running, get_container_name
+from tools.docker_common_tools import get_docker, compose_project_label, container_label_key, \
+    compose_project_dir_label, stack_namespace_label
+from tools.docker_container_tools import is_container_running
 
 compose_service_label = "com.docker.compose.service"
 


### PR DESCRIPTION
Not everybody uses swarm stacks, moreover not everybody knows what it is. So it is better to hide stack counter, when there is none of them exist.